### PR TITLE
docs: enhance `texifast` documentation and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # texifast ![Python Version from PEP 621 TOML](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2FSped0n%2Ftexifast%2Fmain%2Fpyproject.toml) ![PyPI - Version](https://img.shields.io/pypi/v/texifast) ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Sped0n/texifast/pytest.yml?label=pytest)
 
-LaTeX and markdown OCR powered by texify, without bloated dependencies like torch or transformers.
+LaTeX and markdown OCR powered by [texify](https://github.com/VikParuchuri/texify), without bloated dependencies like torch or transformers.
 
 ## Features
 
 - Minimal dependency graph
-- Compared to [Optimum](https://github.com/huggingface/optimum), texifast is faster (5-20%) and has a smaller memory footprint (~30%). For details, see [benchmark](https://github.com/Sped0n/texifast/tree/main/benchmark)
+- Compared to [Optimum](https://github.com/huggingface/optimum), texifast is faster (5-20%) and has a smaller memory footprint (~20%). For details, see [benchmark](https://github.com/Sped0n/texifast/tree/main/benchmark)
 - Supports IOBinding features of ONNXRuntime and optimizes for CUDAExecutionProvider.
 - Supports quantized/mixed precision models.
 
@@ -23,7 +23,7 @@ pip install texifast[all]
 
 ## Quickstart
 
-This quick start use the [image in test folder](https://raw.githubusercontent.com/Sped0n/texifast/main/tests/latex.png), you can use whatever you like, as long as you can convert it to a `PIL.Image` object.
+This quick start use the [image in test folder](https://raw.githubusercontent.com/Sped0n/texifast/main/tests/latex.png), you can use whatever you like.
 
 ```python
 from texifast.model import TxfModel


### PR DESCRIPTION
- Update the description of `texifast` to include a link to the `texify` repository
- Correct the memory footprint comparison with `Optimum` from ~30% to ~20%
- Simplify the quick start instructions by removing the requirement to convert images to `PIL.Image` objects