### PR TITLE
docs: enhance README with model download links and API details

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ texifast = TxfPipeline(model=model, tokenizer="./tokenizer.json")
 print(texifast("./latex.png"))
 ```
 
+> You can download the quantized ONNX model [here](https://huggingface.co/Spedon/texify-quantized-onnx/tree/main) and the FP16 ONNX model [here](https://huggingface.co/Spedon/texify-fp16-onnx/tree/main).
+
 ## API
 
 The full Python API documentation can be found [here](https://github.com/Sped0n/texifast/tree/main/docs).


### PR DESCRIPTION
- Add links to download quantized and FP16 ONNX models
- Update README with additional information about the API