### PR TITLE
feat: refine math blocks in text processing pipeline

### DIFF
--- a/src/texifast/helpers.py
+++ b/src/texifast/helpers.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 
 class _CustomFormatter(logging.Formatter):
@@ -41,3 +42,29 @@ def set_log_level(level: int) -> None:
 
     """
     logger.setLevel(level)
+
+
+def refine_math_block(text: str) -> str:
+    """Refine the math block in the text.
+
+    Args:
+        text (str): The text to refine.
+
+    Returns:
+        str: The refined text.
+    """
+    pattern = r"(\$\$.*?\$\$)"
+    parts: list[str] = re.split(pattern, text, flags=re.DOTALL)
+    last_block_is_math_block: bool = False
+    for i in range(len(parts)):
+        if re.match(pattern, parts[i]):
+            parts[i] = (
+                f"$$\n{parts[i][2:-2]}\n$$\n\n"
+                if last_block_is_math_block
+                else f"\n\n$$\n{parts[i][2:-2]}\n$$\n\n"
+            )
+            last_block_is_math_block = True
+        else:
+            parts[i] = parts[i].strip()
+    result: str = "".join(parts).strip()
+    return result

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,9 @@
+from texifast.helpers import refine_math_block
+
+
+def test_refine_math_block() -> None:
+    text = "This is a math block $$x^2$$ and this is another math block $$y^2$$"
+    assert (
+        refine_math_block(text)
+        == "This is a math block\n\n$$\nx^2\n$$\n\nand this is another math block$$\ny^2\n$$"
+    )


### PR DESCRIPTION
- Add `refine_math_block` function to refine math blocks in text
- Import `re` module for regular expressions in `helpers.py`
- Integrate `refine_math_block` into `TxfPipeline` class with a new `refine_output` parameter
- Add a test for the `refine_math_block` function in `test_helpers.py`